### PR TITLE
Implemented Viewholder Pattern

### DIFF
--- a/app/src/main/java/com/antonioleiva/materialeverywhere/HomeActivity.java
+++ b/app/src/main/java/com/antonioleiva/materialeverywhere/HomeActivity.java
@@ -92,7 +92,7 @@ public class HomeActivity extends BaseActivity {
 
 
         @Override public int getCount() {
-            return 4;
+            return 20;
         }
 
         @Override public Object getItem(int i) {
@@ -103,50 +103,66 @@ public class HomeActivity extends BaseActivity {
             return i;
         }
 
-        @Override public View getView(int i, View view, ViewGroup viewGroup) {
+        @Override public View getView(int i, View convertView, ViewGroup viewGroup) {
 
-            if (view == null) {
-                view = LayoutInflater.from(viewGroup.getContext())
-                        .inflate(R.layout.grid_item, viewGroup, false);
+
+            final ViewHolder viewHolder;
+
+            if (convertView == null) {
+
+                convertView = LayoutInflater.from(viewGroup.getContext()).inflate(
+                    R.layout.grid_item, viewGroup, false);
+
+                viewHolder = new ViewHolder();
+                viewHolder.image = (ImageView) convertView.findViewById(R.id.image);
+                viewHolder.view = convertView.findViewById(R.id.view);
+                viewHolder.text = (TextView) convertView.findViewById(R.id.textpalette);
+
+                convertView.setTag(viewHolder);
+
+            } else {
+
+                viewHolder = (ViewHolder) convertView.getTag();
             }
 
             final String imageUrl = "http://tbremer.pf-control.de/walls/" + String.valueOf(i + 1) + ".png";
-            view.setTag(imageUrl);
-            final ImageView image = (ImageView) view.findViewById(R.id.image);
-            final View view1 = findViewById(R.id.view);
+//            convertView.setTag(imageUrl);
+
+            viewHolder.text.setText(getItem(i).toString());
 
 
+            Picasso.with(convertView.getContext())
+                .load(imageUrl)
+                .fit().centerCrop()
+                .into(viewHolder.image, new Callback.EmptyCallback() {
+                    @Override public void onSuccess() {
+                        final Bitmap bitmap = ((BitmapDrawable) viewHolder.image.getDrawable()).getBitmap();// Ew!
+                        Palette.generateAsync(bitmap, new Palette.PaletteAsyncListener() {
+                            public void onGenerated(Palette palette) {
 
+                                if (palette != null) {
 
+                                    Palette.Swatch vibrantSwatch = palette.getVibrantSwatch();
 
-            Picasso.with(view.getContext())
-                    .load(imageUrl)
-                    .fit().centerCrop()
-                    .into(image, new Callback.EmptyCallback() {
-                        @Override public void onSuccess() {
-                            final Bitmap bitmap = ((BitmapDrawable) image.getDrawable()).getBitmap();// Ew!
-                            Palette.generateAsync(bitmap, new Palette.PaletteAsyncListener() {
-                                public void onGenerated(Palette palette) {
-
-                                    int bgColor = palette.getVibrantColor(android.R.color.white);
-                                    view1.setBackgroundColor(bgColor);
-
+                                    if (vibrantSwatch != null) {
+                                        viewHolder.view.setBackgroundColor(vibrantSwatch.getRgb());
+                                        viewHolder.text.setTextColor(vibrantSwatch.getTitleTextColor());
+                                    }
                                 }
-                            });
-                        }
-                    });
+                            }
+                        });
+                    }
+                });
 
-
-
-            TextView text = (TextView) view.findViewById(R.id.textpalette);
-            text.setText(getItem(i).toString());
-
-
-
-            return view;
+            return convertView;
         }
     }
 
+    static class ViewHolder {
+        ImageView image;
+        TextView text;
+        View view;
+    }
 
 
 


### PR DESCRIPTION
The problem was being caused by a poor implementation of a  _GridView_. Using the __ViewHolder__ [1] pattern allows reusing the views and generate the required exact palette for the required view, the other way was using the palette of unwanted elements.

However, it is highly recommended to use _RecyclerView_ with a _GridLayoutManager_ [3] instead of a _GridView_ with _BaseAdapter_, the _RecyclerView_ helps and implements the pattern.

By the way, you can check an example [4] about a RecyclerView with a GridLayoutManager and Palette, on my GitHub account.

[1] http://developer.android.com/training/improving-layouts/smooth-scrolling.html
[2] https://developer.android.com/reference/android/support/v7/widget/RecyclerView.html
[3] https://developer.android.com/reference/android/support/v7/widget/GridLayoutManager.html
[4] https://github.com/saulmm/OpenLibra-Material